### PR TITLE
Fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ wild = "2.0.1"
 nix = { version = "0.13", optional = true }
 lazy_static = { version = "1.3", optional = true }
 platform-info = { version = "0.0.1", optional = true }
+# * transitive dependency via 'failure'; pin to <= v0.3.30 to avoid increasing MinSRV to v1.33.0
+backtrace = ">= 0.3.3, <= 0.3.30"
 
 [target.'cfg(target_os = "redox")'.dependencies]
 termion = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ appveyor = { repository = "uutils/uucore" }
 
 [dependencies]
 dunce = "1.0.0"
-getopts = "0.2.18"
-failure = { version = "0.1.1", optional = true }
-failure_derive = { version = "0.1.1", optional = true }
-time = { version = "0.1.40", optional = true }
+getopts = "<= 0.2.21"
+failure = { version = "<= 0.1.1", optional = true }
+failure_derive = { version = "<= 0.1.1", optional = true }
+time = { version = "<= 0.1.42", optional = true }
 data-encoding = { version = "^2.1", optional = true }
-libc = { version = "0.2.42", optional = true }
+libc = { version = "<= 0.2.66", optional = true }
 wild = "2.0.1"
-nix = { version = "0.13", optional = true }
+nix = { version = "<= 0.13", optional = true }
 lazy_static = { version = "1.3", optional = true }
-platform-info = { version = "0.0.1", optional = true }
+platform-info = { version = "<= 0.0.1", optional = true }
 # * transitive dependency via 'failure'; pin to <= v0.3.30 to avoid increasing MinSRV to v1.33.0
 backtrace = ">= 0.3.3, <= 0.3.30"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ travis-ci = { repository = "uutils/uucore" }
 appveyor = { repository = "uutils/uucore" }
 
 [dependencies]
+dunce = "1.0.0"
 getopts = "0.2.18"
 failure = { version = "0.1.1", optional = true }
 failure_derive = { version = "0.1.1", optional = true }
@@ -43,4 +44,3 @@ entries = ["libc"]
 zero-copy = ["nix", "libc", "lazy_static", "platform-info"]
 wide = []
 default = []
-

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -6,6 +6,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+#[cfg(windows)]
+extern crate dunce;
 #[cfg(target_os = "redox")]
 extern crate termion;
 
@@ -101,7 +103,7 @@ pub fn canonicalize<P: AsRef<Path>>(original: P, can_mode: CanonicalizeMode) -> 
     let original = if original.is_absolute() {
         original.to_path_buf()
     } else {
-        env::current_dir().unwrap().join(original)
+        dunce::canonicalize(env::current_dir().unwrap()).unwrap().join(original)
     };
 
     let mut result = PathBuf::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod parse_time;
 
 #[cfg(all(not(windows), feature = "mode"))]
 pub mod mode;
-#[cfg(all(unix, not(target_os = "fuchsia"), feature = "utmpx"))]
+#[cfg(all(unix, not(target_os = "fuchsia"), not(target_env="musl"), feature = "utmpx"))]
 pub mod utmpx;
 #[cfg(all(unix, feature = "entries"))]
 pub mod entries;


### PR DESCRIPTION
This PR is proof-of-concept to fix ...

- uucore::fs for windows hosts causing build errors for coreutils
- pinning 'backtrace' version (transitive dependency via 'failure') to prevent a forced increase in MinSRV
- and pinning versions < v1.0.0 to hopefully minimize further episodes of forced MinSRV changes

There is an [issue](https://github.com/rust-lang-nursery/failure/issues/340) requesting that the failure crate actually pins it's own crate versions to abide by its own MinSRV claim. And this can be updated to include that update if/when it occurs. Although, it looks like it's going to be a "no-fix" / "works as designed" final answer.

I can split this up if requested. I just wanted to get it to allow for evaluation and discussion of the issues.