### PR TITLE
Use OsString for arguments rather than String

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -70,7 +70,22 @@ pub use crate::features::wide;
 
 //## core functions
 
+use std::ffi::OsString;
+
+pub trait Args: Iterator<Item = OsString> + Sized {
+    fn collect_str(self) -> Vec<String> {
+	// FIXME: avoid unwrap()
+	self.map(|s| s.into_string().unwrap()).collect()
+    }
+}
+
+impl<T: Iterator<Item = OsString> + Sized> Args for T { }
+
 // args() ...
 pub fn args() -> impl Iterator<Item = String> {
     wild::args()
+}
+
+pub fn args_os() -> impl Iterator<Item = OsString> {
+    wild::args_os()
 }

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -69,7 +69,7 @@ pub fn main(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     };
     proc_dbg!(&expr);
 
-    let f = quote::quote! { #expr(uucore::args().collect()) };
+    let f = quote::quote! { #expr(uucore::args_os()) };
     proc_dbg!(&f);
 
     // generate a uutils utility `main()` function, tailored for the calling utility


### PR DESCRIPTION
This is a separate PR from the previous one.  I think I will rebase the other one on top of this.  I will need to send corresponding PRs in the `coreutils` repo as well.  Unlike the previous PR, there is basically no chance of breakage once the PRs in the `coreutils` repo are in place.