### PR TITLE
Formatting

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -74,12 +74,12 @@ use std::ffi::OsString;
 
 pub trait Args: Iterator<Item = OsString> + Sized {
     fn collect_str(self) -> Vec<String> {
-	// FIXME: avoid unwrap()
-	self.map(|s| s.into_string().unwrap()).collect()
+        // FIXME: avoid unwrap()
+        self.map(|s| s.into_string().unwrap()).collect()
     }
 }
 
-impl<T: Iterator<Item = OsString> + Sized> Args for T { }
+impl<T: Iterator<Item = OsString> + Sized> Args for T {}
 
 // args() ...
 pub fn args() -> impl Iterator<Item = String> {

--- a/src/lib/macros.rs
+++ b/src/lib/macros.rs
@@ -180,7 +180,11 @@ macro_rules! msg_opt_only_usable_if {
         msg_invalid_opt_use!(format!("only usable if {}", $clause), $flag)
     };
     ($clause:expr, $long_flag:expr, $short_flag:expr) => {
-        msg_invalid_opt_use!(format!("only usable if {}", $clause), $long_flag, $short_flag)
+        msg_invalid_opt_use!(
+            format!("only usable if {}", $clause),
+            $long_flag,
+            $short_flag
+        )
     };
 }
 


### PR DESCRIPTION
Apparently Emacs formats Rust code somewhat bizarrely by default.